### PR TITLE
Pulling change from Levirak "Spidersatchel tweaks"

### DIFF
--- a/src/items/equipment/spidersatchel.json
+++ b/src/items/equipment/spidersatchel.json
@@ -88,10 +88,25 @@
     },
     "equippable": true,
     "equipped": false,
-    "equippedBulkMultiplier": 1,
+    "equippedBulkMultiplier": 0,
     "identified": false,
     "level": 3,
-    "modifiers": [],
+    "modifiers": [
+      {
+        "_id": "ff4e55f0-25f1-4102-8b3c-f45005a3f279",
+        "name": "Spidersatchel",
+        "type": "enhancement",
+        "condition": "",
+        "effectType": "bulk",
+        "enabled": true,
+        "modifier": 3,
+        "modifierType": "constant",
+        "notes": "",
+        "source": "AP #29 pg. 53",
+        "subtab": "misc",
+        "valueAffected": ""
+      }
+    ],
     "price": 1200,
     "quantity": 1,
     "source": "AP #29 pg. 53"


### PR DESCRIPTION
I thank you kindly for catching that. 

from levirak "The Spidersatchel should be weightless when equipped, just like the Commercial or Industrial Backpacks. It was likewise missing a modifier to encumbrance." 